### PR TITLE
chore: sync with upstream to `15acb40`

### DIFF
--- a/cmd/firestark/cli/common-flag.go
+++ b/cmd/firestark/cli/common-flag.go
@@ -38,7 +38,7 @@ func init() {
 		cmd.Flags().String("common-blocks-cache-dir", BlocksCacheDirectory, FlagDescription(`
 			[COMMON] Blocks cache directory where all the block's bytes will be cached to disk instead of being kept in RAM.
 			This should be a disk that persists across restarts of the Firehose component to reduce the the strain on the disk
-			when restarting and streams reconnects. The size of disk must at least big (with a 10% buffer) in bytes as the sum of flags'
+			when restarting and streams reconnects. The size of disk must at least big (with a 10%% buffer) in bytes as the sum of flags'
 			value for  'common-blocks-cache-max-recent-entry-bytes' and 'common-blocks-cache-max-entry-by-age-bytes'.
 		`))
 		cmd.Flags().Int("common-blocks-cache-max-recent-entry-bytes", 21474836480, FlagDescription(`

--- a/cmd/firestark/cli/constants.go
+++ b/cmd/firestark/cli/constants.go
@@ -38,7 +38,7 @@ const (
 	// sync the chain with the blockchain network. For example on Ethereum where
 	// our standard instrumentation if using the Geth client, value is `geth`, on EOSIO
 	// chain, it's `nodeos`.
-	ChainExecutableName = "dchain"
+	ChainExecutableName = "dummy-blockchain"
 
 	//
 	/// Standard Values

--- a/tools/fireacme/99-firehose.sh
+++ b/tools/fireacme/99-firehose.sh
@@ -4,15 +4,4 @@
 # connect on the box.
 export PATH=$PATH:/app
 
-# If we are in a "node-manager" image, display special scripts motd#
-#
-# *Note* Our (i.e. firehose-acme) reader data directory is at the root
-#        `/data` mount point. Inside it, the `dummmy-blockchain` binary
-#        itself creates a `data` subfolder. This is why we have `/data/data`
-#        here as the path to check if we are inside a Node Manager instance
-#        or a pure process (i.e. without Node Manager)
-if [[ -d /data/data ]]; then
-  cat /etc/motd_node_manager
-else
-  cat /etc/motd_generic
-fi
+cat /etc/motd


### PR DESCRIPTION
This PR ports changes relevant to this fork in these upstream commits:

- [3bcf1eb](https://github.com/streamingfast/firehose-acme/commit/3bcf1eb)
- [eb149ba](https://github.com/streamingfast/firehose-acme/commit/eb149ba)
- [15acb40](https://github.com/streamingfast/firehose-acme/commit/15acb40)