### PR TITLE
feat: support decoding `DeployAccount` transactions

### DIFF
--- a/codec/console_reader.go
+++ b/codec/console_reader.go
@@ -230,6 +230,8 @@ func (ctx *parseCtx) trxBegin(params []string) error {
 		trx.Type = pbacme.TransactionType_DECLARE
 	case "L1_HANDLER":
 		trx.Type = pbacme.TransactionType_L1_HANDLER
+	case "DEPLOY_ACCOUNT":
+		trx.Type = pbacme.TransactionType_DEPLOY_ACCOUNT
 	default:
 		return fmt.Errorf("unknown transaction type: %s", params[1])
 	}


### PR DESCRIPTION
This PR maps the `DEPLOY_ACCOUNT` transaction type in the Firehose log to the corresponding protobuf value introduced in #3.