### PR TITLE
chore: update image versions used in example

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,7 +10,7 @@
 version: "3.8"
 services:
   reader:
-    image: "starknet/firestark:0.1.0-pathfinder-0.3.5"
+    image: "starknet/firestark:0.1.1-pathfinder-0.3.8"
     user: "root"
     command:
       - "--config-file"
@@ -28,7 +28,7 @@ services:
       - "./pathfinder-data:/pathfinder-data"
 
   merger:
-    image: "starknet/firestark:0.1.0"
+    image: "starknet/firestark:0.1.1"
     command:
       - "--config-file"
       - ""
@@ -42,7 +42,7 @@ services:
       - "./firehose-data:/firehose-data"
 
   relayer:
-    image: "starknet/firestark:0.1.0"
+    image: "starknet/firestark:0.1.1"
     command:
       - "--config-file"
       - ""
@@ -56,7 +56,7 @@ services:
       - "./firehose-data:/firehose-data"
 
   firehose:
-    image: "starknet/firestark:0.1.0"
+    image: "starknet/firestark:0.1.1"
     command:
       - "--config-file"
       - ""


### PR DESCRIPTION
New images have been built, this PR updates the example `docker-compose.yml` file to use the new ones.